### PR TITLE
feat: refine numbering and figure templates in course files

### DIFF
--- a/000-Einleitung/Einleitung.md
+++ b/000-Einleitung/Einleitung.md
@@ -1,0 +1,15 @@
+---
+lang: de-DE
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
+---
+# Einleitung
+
+**Kapitelinhalt:**
+1. [](./Kursinhalte.md)
+2. [](./Spezifika_Fernstudium.md)
+3. [](./Nutzung_des_Kurses.md)

--- a/000-Einleitung/Kursinhalte.md
+++ b/000-Einleitung/Kursinhalte.md
@@ -1,30 +1,38 @@
 ---
 lang: de-DE
-title: Kursinhalte
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
-# Einleitung
+# Kursinhalte
+
+
+## Einleitung
 In der Einleitung werden die Inhalte des Kurses jeweils kurz vorgestellt. Zudem wird auf Spezifika des Fernstudiums eingegangen und es werden Hinweise zur Nutzung der Kursmaterialien gegeben.
 
-# Installation und technische Voraussetzungen
+## Installation und technische Voraussetzungen
 In diesem Kapitel wird erläutert, wie die technischen Voraussetzungen für die Durcharbeit des Kurses hergestellt werden können und wie die Inhalte durch Lernende am besten genutzt werden sollten. Zudem gibt es technsiche Anleitungen für die Arbeit mit den {term}`Jupyter Notebook`s.
 
-# Exkurs: Unix
+## Exkurs: Unix
 In diesem Kapitel wird auf relevante Eigenschaften von Unix-kompatiblen Betriebssystemen eingegangen. Insbesondere gibt es auch eine Einführung in die Nutzung einer Unix Shell.
 
-# Projekt: Python als Taschenrechner
+## Projekt: Python als Taschenrechner
 Das erste Projekt steigt ein in die Nutzung von Python als Taschenrechner. Am Ende des Projekts können Lernende mathematische Funktionen in Python umsetzen und in der {term}`REPL` oder in einem Notebook nutzen.
 
-# Projekt: Zählen einer ISBN in einem Datensatz (CSV)
+## Projekt: Zählen einer ISBN in einem Datensatz (CSV)
 In diesem Projekt werden Daten aus einer CSV-Datei eingelesen und es werden die Vorkommen einer bestimmten ISBN gezählt. Am Ende können Lernende das Programm anpassen, um andere Elemente der CSV-Datei zu zählen.
 
-# Exkurs: Git
+## Exkurs: Git
 In diesem Exkurs wird die Versionsverwaltungssoftware Git vorgestellt. Lernende können nach Absolvieren des Exkurses an einfachen Projekten, die in Git versioniert werden, mitarbeiten.
 
-# Projekt: Statistiken eines Datensatzes (CSV)
+## Projekt: Statistiken eines Datensatzes (CSV)
 Das vorherige Projektergebnis, in dem Elemente in einer CSV-Datei gezählt wurden, wird erweitert, bis das Programm eine vollständige, beschreibende Statistik zur Datei ausgibt.
 
-# Projekt: MARC-XML lesen, filtern und in Bibtex-Datei überführen
+## Projekt: MARC-XML lesen, filtern und in Bibtex-Datei überführen
 In diesem Projekt wird ein Auszug aus einem Katalog im Format MARC-XML eingelesen, es werden Einträge gefiltert und anschließend werden die Ergebnisdaten als Bibtex-Datei bereitgestellt.
 
-# Projekt: Statistiken und Visualisierungen auf Basis einer Excel-Datei
+## Projekt: Statistiken und Visualisierungen auf Basis einer Excel-Datei
 Im Abschlussprojekt werden noch unaufbereitete Daten in einer Excel-Datei bereinigt, für die weitere Verarbeitung aufbereitet und dann statistisch beschrieben. Das Projekt schließt mit Visualisierungen der interessantesten Ergebnisse.

--- a/000-Einleitung/Nutzung_des_Kurses.md
+++ b/000-Einleitung/Nutzung_des_Kurses.md
@@ -1,13 +1,19 @@
 ---
 lang: de-DE
-title: Nutzung des Kurses
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Nutzung des Kurses
 Um den Selbstlernkurs möglichst gewinnbringend zu nutzen müssen Sie eine gewisse Arbeitsleistung einbringen. Wenn Sie den Kurs nur _lesen_, so werden Sie nur ein sehr basales Wissen erlangen. Die nächst-intensivere Art der Interaktion ist das _Bearbeiten_ der Aufgaben und ggf. das _Experimentieren_ mit den Lösungen. Die intensivste Art der Interaktion ist das _Programmieren_ eigener Lösungen und das _Erstellen_ eigener Projekte.
 
 Nutzen Sie alle eingebauten Feedback-Möglichkeiten um Ihr Selbststudium zu steuern. Was können Sie schon, was nicht? Welche Inhalte sollten Sie nochmal wiederholen? Können Sie das gelernte auf ein ähnliches Problem anwenden?
 
-# Nutzungsformen
+## Nutzungsformen
 
-# Self-Assessment
+## Self-Assessment
 
-# Übungsprojekte
+## Übungsprojekte

--- a/000-Einleitung/Spezifika_Fernstudium.md
+++ b/000-Einleitung/Spezifika_Fernstudium.md
@@ -1,17 +1,24 @@
 ---
 lang: de-DE
-title: Spezifika für Studierende des Fernstudiums
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
-# Struktur der Lehrgebiete 01.05 und 07.05
+# Spezifika für Studierende des Fernstudiums
+
+## Struktur der Lehrgebiete 01.05 und 07.05
 
 Der Selbstlernkurs ist während des gesamten Studiums bearbeitbar. Sie können ihn ab der Eröffnungssitzung (Lehrgebiet 01.05) beginnen. In dieser Sitzung wird der Kurs vorgestellt und alle Formalitäten vorgestellt. Sie können mit einem kleinen Beispiel gleich praktisch einsteigen und dann im Selbststudium weiterarbeiten. Anfang des dritten Semesters findet eine Abschlussitzung statt (Lehrgebiet 07.05), in der Probleme besprochen und Ergebnisse vorgestellt werden können. Sie können den Selbstlernkurs auch nach der Abschlusssitzung noch weiter bearbeiten. Einzige Frist für eine Anrechnung der Kleinen Aufgaben in diesen zwei Lehrgebieten sind die allgemeinen Fristen für Kleine Aufgaben.
 
-# Konsultationen
+## Konsultationen
 Anfang des ersten Semesters findet die Einführungskonsultation statt. In dieser wird motiviert, weshalb Sie den Selbstlernkurs absolvieren sollten. Es wird klargestellt, auf welcher Kompetenzebene der Kurs angesetzt ist und was Sie für sich nach vollständigem Absolvieren des Kurses erwarten können. Die Konsultation stellt die technischen Voraussetzungen für die Bearbeitung des Kurses vor und steigt dann mit einem kleinen Projekt ein, welches in der Sitzung bearbeitet wird.
 
 Die Abschlusskonsultation im dritten Semester ist vorrangig für die Studierenden konzipiert, welche den Selbstlernkurs (ganz oder teilweise) absolviert haben oder dies noch vorhaben. Vor der Sitzung können Sie Ihre Fragen und Problemfälle anbringen. Des weiteren werden besonders gute Lösungen vorgestellt. Die Konsultation kann auch genutzt werden um Fragen zur Nutzung von Python in der Masterarbeit zu stellen.
 
-# Kleine Aufgaben
+## Kleine Aufgaben
 Sie können für den Selbstlernkurs bis zu zwei Kleine Aufgaben geltend machen. Übungen, welche Sie für eine Kleine Aufgabe geltend machen können sind entsprechend gekennzeichnet.
 
 Die Kleinen Aufgaben können in Modul 1 und Modul 2 angerechnet werden. Es kann jeweils maximal eine Kleine Aufgabe angerechnet werden. Dies ergibt sich daraus, dass es ein Lehrgebiet in Modul 1 gibt (01.05) und ebenso ein Lehrgebiet in Modul 2 (07.05). Sie selbst entscheiden am Ende des Studiums bei der Abgabe der Nachweise der Kleinen Aufgaben, in welchem Modul Sie die in diesem Kurs erlangten Nachweise geltend machen.

--- a/010-Installation_Technik/Einleitung.md
+++ b/010-Installation_Technik/Einleitung.md
@@ -1,4 +1,10 @@
 ---
 lang: de-DE
-title: Installation und technische Voraussetzungen
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Installation und technische Voraussetzungen

--- a/020-Projekt_Taschenrechner/Einleitung.md
+++ b/020-Projekt_Taschenrechner/Einleitung.md
@@ -1,8 +1,13 @@
 ---
 lang: de-DE
-title: Projektbeschreibung
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
-
+# Projekt: Python als Taschenrechner
 :::{important} Lernziele
 In diesem Kapitel erlernen Sie, …
 - … welche mathematischen Operationen in Python unterstützt werden.

--- a/030-Exkurs_Unix/Einleitung.md
+++ b/030-Exkurs_Unix/Einleitung.md
@@ -1,4 +1,10 @@
 ---
 lang: de-DE
-title: Einleitung
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Exkurs: Unix

--- a/040-Projekt_CSV_I/Einleitung.md
+++ b/040-Projekt_CSV_I/Einleitung.md
@@ -1,4 +1,10 @@
 ---
 lang: de-DE
-title: Projektbeschreibung
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Projekt: Zählen einer ISBN in einem Datensatz (CSV)

--- a/050-Exkurs_Git/Einleitung.md
+++ b/050-Exkurs_Git/Einleitung.md
@@ -1,4 +1,10 @@
 ---
 lang: de-DE
-title: Einleitung
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Exkurs: Git

--- a/060-Projekt_CSV_II/Einleitung.md
+++ b/060-Projekt_CSV_II/Einleitung.md
@@ -1,4 +1,10 @@
 ---
 lang: de-DE
-title: Projektbeschreibung
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Projekt: Statistiken eines Datensatzes (CSV)

--- a/070-Projekt_MARC-XML/Einleitung.md
+++ b/070-Projekt_MARC-XML/Einleitung.md
@@ -1,4 +1,10 @@
 ---
 lang: de-DE
-title: Projektbeschreibung
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Projekt: MARC-XML lesen, filtern und in Bibtex-Datei überführen

--- a/080-Projekt_Excel/Einleitung.md
+++ b/080-Projekt_Excel/Einleitung.md
@@ -1,4 +1,10 @@
 ---
 lang: de-DE
-title: Projektbeschreibung
+numbering:
+  heading_1: true
+  heading_2: true
+  title: true
+  figure:
+    template: Abb. %s
 ---
+# Projekt: Statistiken und Visualisierungen auf Basis einer Excel-Datei

--- a/999-Epilog/Glossar.md
+++ b/999-Epilog/Glossar.md
@@ -1,7 +1,7 @@
 ---
 lang: de-DE
-title: Glossar
 ---
+# Glossar
 :::{glossary}
 Jupyter
 : Das [_project jupyter_](https://jupyter.org) ist eine Sammlung von Standards, Projekten und Dienstleistungen zur programmiersprachenübergreifenden Entwicklung interaktiver Rechenumgebungen.

--- a/999-Epilog/Impressum.md
+++ b/999-Epilog/Impressum.md
@@ -1,4 +1,4 @@
 ---
 lang: de-DE
-title: Impressum
 ---
+# Impressum

--- a/999-Epilog/Index.md
+++ b/999-Epilog/Index.md
@@ -1,6 +1,7 @@
 ---
 lang: de-DE
-title: Index
 ---
+# Index
+
 ```{show-index}
 ```

--- a/index.md
+++ b/index.md
@@ -1,9 +1,9 @@
 ---
 lang: de-DE
-title: Selbstlernkurs Python
 subtitle: entwickelt für die Lehrgebiete 1.5/7.5 im weiterbildenden Masterstudiengang Bibliotheks- und Informationswissenschaft im Fernstudium an der Humboldt-Universität zu Berlin
 ---
-# Einführung
+# Selbstlernkurs Python
+## Einführung
 
 :::{important} Lernziele
 In diesem Selbstlernkurs erlernen Sie:
@@ -15,9 +15,9 @@ Dieser Selbstlernkurs richtet sich an angehende Bibliotheks- und Informationswis
 
 Als Lernende\*r erarbeiten Sie sich die Inhalte dieses Kurses selbstbestimmt. Haben Sie schon Erfahrungen mit dem Programmieren und ggf. sogar schon in Python, so können Sie Teile des Kurses überspringen und Inhalte nach Bedarf auswählen. Starten Sie jedoch ganz neu, so sollten Sie den Kurs in der vorgegebenen Reihenfolge durcharbeiten.
 
-Die einzelnen Kapitel des Kurses werden auf der nächsten Seite kurz beschrieben. Als Lernende\*r können Sie die Inhalte zur [Nutzung des Kurses](Einleitung/Nutzung_des_Kurses.md) überspringen. Sie richten sich vor allem an Personen, die den Kurs in Ihren eigenen Lehrveranstaltungen einsetzen wollen.
+Die einzelnen Kapitel des Kurses werden auf der nächsten Seite kurz beschrieben. Als Lernende\*r können Sie die Inhalte zur [Nutzung des Kurses](000-Einleitung/Nutzung_des_Kurses.md) überspringen. Sie richten sich vor allem an Personen, die den Kurs in Ihren eigenen Lehrveranstaltungen einsetzen wollen.
 
-# Inhaltsverzeichnis
+## Inhaltsverzeichnis
 ```{table-of-contents}
 :depth: 2
 ```

--- a/myst.yml
+++ b/myst.yml
@@ -41,7 +41,5 @@ site:
     favicon: assets/favicon.ico
     logo: assets/logo.png
     folders: true
-    numbering:
-      headings: true
-      title: true
+    
 

--- a/toc.yml
+++ b/toc.yml
@@ -2,35 +2,20 @@ version: 1
 project:
   id: 009c9d71-a4fc-4438-8118-31289551ac9
   toc:
-    - file: intro.md
-    - title: Einleitung
+    - file: index.md
+    - file: 000-Einleitung/Einleitung.md
       children:
         - file: 000-Einleitung/Kursinhalte.md
         - file: 000-Einleitung/Spezifika_Fernstudium.md
         - file: 000-Einleitung/Nutzung_des_Kurses.md
-    - title: Installation und technische Voraussetzungen
-      file: 010-Installation_Technik/Einleitung.md
-    - title: "Projekt: Python als Taschenrechner"
-      children:
-        - file: 020-Projekt_Taschenrechner/Einleitung.md
-    - title: "Exkurs: Unix"
-      children:
-        - file: 030-Exkurs_Unix/Einleitung.md
-    - title: "Projekt: Zählen einer ISBN in einem Datensatz (CSV)"
-      children:
-        - file: 040-Projekt_CSV_I/Einleitung.md
-    - title: "Exkurs: Git"
-      children:
-        - file: 050-Exkurs_Git/Einleitung.md
-    - title: "Projekt: Statistiken eines Datensatzes (CSV)"
-      children:
-        - file: 060-Projekt_CSV_II/Einleitung.md
-    - title: "Projekt: MARC-XML lesen, filtern und in Bibtex-Datei überführen"
-      children:
-        - file: 070-Projekt_MARC-XML/Einleitung.md
-    - title: "Projekt: Statistiken und Visualisierungen auf Basis einer Excel-Datei"
-      children:
-        - file: 080-Projekt_Excel/Einleitung.md
+    - file: 010-Installation_Technik/Einleitung.md
+    - file: 020-Projekt_Taschenrechner/Einleitung.md
+    - file: 030-Exkurs_Unix/Einleitung.md
+    - file: 040-Projekt_CSV_I/Einleitung.md
+    - file: 050-Exkurs_Git/Einleitung.md
+    - file: 060-Projekt_CSV_II/Einleitung.md
+    - file: 070-Projekt_MARC-XML/Einleitung.md
+    - file: 080-Projekt_Excel/Einleitung.md
     - title: Epilog
       children:
         - file: 999-Epilog/Glossar.md


### PR DESCRIPTION
Update numbering configuration to enable heading_1 and heading_2 levels
instead of the generic headings option across multiple markdown files.
Add a figure template "Abb. %s" to standardize figure captions in all
course introduction and project files.